### PR TITLE
Updated Card Packs with Themed Images

### DIFF
--- a/src/components/game/CardPackItem.vue
+++ b/src/components/game/CardPackItem.vue
@@ -2,6 +2,11 @@
 import { ref, computed } from 'vue'
 import type { CardPack } from '@/types/game'
 
+// 🖼 Import your new themed images
+import wizardImage from '@/assets/images/packs/wizard_pack.png'
+import warriorImage from '@/assets/images/packs/warrior_pack.png'
+import ninjaImage from '@/assets/images/packs/ninja_pack.png'
+
 const props = defineProps<{
   pack: CardPack
   isSelected: boolean
@@ -23,6 +28,20 @@ const handleClick = () => {
   emit('select', props.pack)
 }
 
+// 🪄 Helper: decide which image to show for each pack
+const getPackImage = (name: string) => {
+  switch (name) {
+    case 'Mystic Pack':
+      return wizardImage
+    case 'Warrior Pack':
+      return warriorImage
+    case 'Shadow Pack':
+      return ninjaImage
+    default:
+      return wizardImage
+  }
+}
+
 const shouldHide = computed(() => {
   return props.isAnimating && !props.isSelected
 })
@@ -41,7 +60,7 @@ const shouldCenter = computed(() => {
     ]"
     @click="handleClick"
   >
-    <!-- Stars Animation -->
+    <!-- ✨ Stars Animation -->
     <Transition name="stars">
       <div v-if="showStars && isSelected" class="absolute inset-0 pointer-events-none">
         <div
@@ -59,7 +78,7 @@ const shouldCenter = computed(() => {
       </div>
     </Transition>
 
-    <!-- Card Pack -->
+    <!-- 🎴 Card Pack -->
     <div
       :class="[
         'bg-gradient-to-br rounded-2xl shadow-2xl p-8 w-64 h-80 flex flex-col items-center justify-center transform transition-all',
@@ -68,33 +87,28 @@ const shouldCenter = computed(() => {
         isShaking && isSelected ? 'animate-shake' : '',
       ]"
     >
-      <div class="text-7xl mb-4">{{ pack.emoji }}</div>
+      <!-- 🖼 Display Pack Image -->
+      <img
+        :src="getPackImage(pack.name)"
+        :alt="`${pack.name} image`"
+        class="w-40 h-40 object-contain rounded-lg mb-4"
+      />
+
       <h3 class="text-3xl font-bold text-white mb-2 text-center">{{ pack.name }}</h3>
       <p class="text-white/90 text-center">{{ pack.description }}</p>
-      <div class="mt-4 text-6xl">🎴</div>
     </div>
   </div>
 </template>
 
 <style scoped>
 @keyframes shake {
-  0%,
-  100% {
+  0%, 100% {
     transform: translate(-50%, -50%) rotate(0deg);
   }
-
-  10%,
-  30%,
-  50%,
-  70%,
-  90% {
+  10%, 30%, 50%, 70%, 90% {
     transform: translate(-50%, -50%) rotate(-5deg);
   }
-
-  20%,
-  40%,
-  60%,
-  80% {
+  20%, 40%, 60%, 80% {
     transform: translate(-50%, -50%) rotate(5deg);
   }
 }
@@ -104,94 +118,26 @@ const shouldCenter = computed(() => {
 }
 
 @keyframes star-burst {
-  0% {
-    transform: translate(-50%, -50%) scale(0);
-    opacity: 1;
-  }
-
-  100% {
-    transform: translate(var(--x), var(--y)) scale(1);
-    opacity: 0;
-  }
+  0% { transform: translate(-50%, -50%) scale(0); opacity: 1; }
+  100% { transform: translate(var(--x), var(--y)) scale(1); opacity: 0; }
 }
 
-.star-1 {
-  animation: star-burst 1s ease-out forwards;
-  --x: 0px;
-  --y: -150px;
-}
-
-.star-2 {
-  animation: star-burst 1s ease-out 0.05s forwards;
-  --x: 100px;
-  --y: -100px;
-}
-
-.star-3 {
-  animation: star-burst 1s ease-out 0.1s forwards;
-  --x: 150px;
-  --y: 0px;
-}
-
-.star-4 {
-  animation: star-burst 1s ease-out 0.15s forwards;
-  --x: 100px;
-  --y: 100px;
-}
-
-.star-5 {
-  animation: star-burst 1s ease-out 0.2s forwards;
-  --x: 0px;
-  --y: 150px;
-}
-
-.star-6 {
-  animation: star-burst 1s ease-out 0.25s forwards;
-  --x: -100px;
-  --y: 100px;
-}
-
-.star-7 {
-  animation: star-burst 1s ease-out 0.3s forwards;
-  --x: -150px;
-  --y: 0px;
-}
-
-.star-8 {
-  animation: star-burst 1s ease-out 0.35s forwards;
-  --x: -100px;
-  --y: -100px;
-}
-
-.star-9 {
-  animation: star-burst 1s ease-out 0.4s forwards;
-  --x: 70px;
-  --y: -130px;
-}
-
-.star-10 {
-  animation: star-burst 1s ease-out 0.45s forwards;
-  --x: 130px;
-  --y: 70px;
-}
-
-.star-11 {
-  animation: star-burst 1s ease-out 0.5s forwards;
-  --x: -70px;
-  --y: 130px;
-}
-
-.star-12 {
-  animation: star-burst 1s ease-out 0.55s forwards;
-  --x: -130px;
-  --y: -70px;
-}
+/* ⭐ Star burst positions */
+.star-1 { animation: star-burst 1s ease-out forwards; --x: 0px; --y: -150px; }
+.star-2 { animation: star-burst 1s ease-out 0.05s forwards; --x: 100px; --y: -100px; }
+.star-3 { animation: star-burst 1s ease-out 0.1s forwards; --x: 150px; --y: 0px; }
+.star-4 { animation: star-burst 1s ease-out 0.15s forwards; --x: 100px; --y: 100px; }
+.star-5 { animation: star-burst 1s ease-out 0.2s forwards; --x: 0px; --y: 150px; }
+.star-6 { animation: star-burst 1s ease-out 0.25s forwards; --x: -100px; --y: 100px; }
+.star-7 { animation: star-burst 1s ease-out 0.3s forwards; --x: -150px; --y: 0px; }
+.star-8 { animation: star-burst 1s ease-out 0.35s forwards; --x: -100px; --y: -100px; }
+.star-9 { animation: star-burst 1s ease-out 0.4s forwards; --x: 70px; --y: -130px; }
+.star-10 { animation: star-burst 1s ease-out 0.45s forwards; --x: 130px; --y: 70px; }
+.star-11 { animation: star-burst 1s ease-out 0.5s forwards; --x: -70px; --y: 130px; }
+.star-12 { animation: star-burst 1s ease-out 0.55s forwards; --x: -130px; --y: -70px; }
 
 .stars-enter-active {
   transition: opacity 0.3s ease;
 }
-
-.stars-enter-from {
-  opacity: 0;
-}
+.stars-enter-from { opacity: 0; }
 </style>


### PR DESCRIPTION
## Description

<!-- Add a description of the changes. You can paste the issue/feature description  -->
Replaced the placeholder card pack graphics on the “Select a Pack” screen with the new themed assets: Wizard, Warrior, and Ninja. Each pack now displays its correct image with proper alt text and responsive sizing. No functional changes were made — this is purely a visual update.

## Type of Change

<!-- Please check the relevant option(s) -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [x] 🎨 UI/Style update
- [ ] ♻️ Refactoring

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #5

## Changes Made

<!-- List the main changes made in this PR -->

- Added themed card pack images (Wizard, Warrior, Ninja) from /src/assets/images/packs.
- Updated the “Select a Pack” screen to display the correct image for each pack.
- Ensured proper alt text and responsive sizing for all pack images.

## Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<img width="1903" height="920" alt="Screenshot 2025-10-12 035212" src="https://github.com/user-attachments/assets/cd79b02e-dc87-47d8-a6b0-2f9ac58be697" />


### Test Steps

<!-- Provide steps to test the changes -->

1. Navigate to the “Select a Pack” screen.
2. Verify that the Wizard, Warrior, and Ninja packs show their respective images.
3. Check that the images resize correctly on different screen sizes.
4. Confirm that no functionality or behavior has change

## Checklist

<!-- Check all that apply -->

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Components are properly typed (TypeScript)


