### PR TITLE
Fix: api returns images that redirect to tumblr violation warning

### DIFF
--- a/src/composables/cards.ts
+++ b/src/composables/cards.ts
@@ -50,7 +50,6 @@ export function useCards() {
     }
 
     // Keep fetching until we have exactly amount of valid images
-    // Amount is 5 now
     while (validImages.length < amount) {
       const needed = amount - validImages.length
       // Over-fetch (2x needed, minimum 10) to reduce loops.


### PR DESCRIPTION
## Description

Fixed issue #23 that caused some Cat API image URLs to redirect to Tumblr’s content-violation placeholder instead of actual cat photos. Currently filtering out Tumblr sources to ensure reliable image delivery, the image fetching process should be more stable.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] 🎨 UI/Style update
- [ ] ♻️ Refactoring

## Related Issues

Closes #23 

## Changes Made

- Introduce `isValidImageUrl` to block problematic hosts (tumblr.com, 64.media.tumblr.com, static.tumblr.com).
- Change `fetchCatImages` to loop until the valid amount of images are collected.
- Validate fetched URLs via `isValidImageUrl` before adding; assign `images.value` from validated list

### Test Steps

1. Start the dev server and open the app
2. Open a pack multiple times (10+ attempts). 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation **(No functional behavior changed)**
- [x] My changes generate no new warnings or errors
- [x] Components are properly typed (TypeScript)

New to Hacktoberfest and this project. Happy to make any adjustments needed!


