### PR TITLE
feat: save user progress between sessions (#19)

### DIFF
--- a/src/components/game/BattleScene.vue
+++ b/src/components/game/BattleScene.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useCards } from '@/composables/cards'
+import { useGameStore } from '@/stores/gameStore'
 import type { CatCard } from '@/types/game'
 import CatCardItem from '@/components/game/CatCardItem.vue'
+import CollectionModal from '@/components/modals/CollectionModal.vue'
 import deckImage from '@/assets/images/game/deck.png'
 import ogreMinion from '@/assets/images/enemies/ogre_minion.png'
 
 const { cards } = useCards()
+const gameStore = useGameStore()
 const showHand = ref(false)
+const showCollection = ref(false)
 
 // Player's hand and battlefield
 const playerHand = ref(cards.value.slice(0, 5))
@@ -15,18 +19,26 @@ const playerField = ref<(CatCard | null)[]>([null, null, null])
 
 const playCard = (card: CatCard) => {
   // Find first available slot
-  const emptySlotIndex = playerField.value.findIndex(slot => slot === null)
+  const emptySlotIndex = playerField.value.findIndex((slot) => slot === null)
 
   if (emptySlotIndex !== -1) {
     // Place card in slot
     playerField.value[emptySlotIndex] = card
 
     // Remove card from hand
-    const handIndex = playerHand.value.findIndex(c => c.id === card.id)
+    const handIndex = playerHand.value.findIndex((c) => c.id === card.id)
     if (handIndex !== -1) {
       playerHand.value.splice(handIndex, 1)
     }
   }
+}
+
+const openCollection = () => {
+  showCollection.value = true
+}
+
+const closeCollection = () => {
+  showCollection.value = false
 }
 
 onMounted(() => {
@@ -40,18 +52,26 @@ onMounted(() => {
 <template>
   <div class="w-full h-screen flex flex-col relative overflow-hidden">
     <!-- Battle Arena Background -->
-    <div class="absolute inset-0 bg-gradient-to-b from-purple-900 via-slate-800 to-green-900 opacity-40"></div>
+    <div
+      class="absolute inset-0 bg-gradient-to-b from-purple-900 via-slate-800 to-green-900 opacity-40"
+    ></div>
 
     <!-- Opponent Area (Top) -->
     <div class="flex-1 flex items-center justify-center relative z-10">
       <div class="text-center">
         <!-- Enemy Image -->
-        <img :src="ogreMinion" alt="Enemy" class="w-64 h-64 object-contain drop-shadow-2xl animate-float" />
+        <img
+          :src="ogreMinion"
+          alt="Enemy"
+          class="w-64 h-64 object-contain drop-shadow-2xl animate-float"
+        />
 
         <!-- Enemy Health Bar -->
         <div class="mt-4 w-64 mx-auto">
           <div class="bg-gray-800 rounded-full h-6 overflow-hidden border-2 border-gray-600">
-            <div class="bg-gradient-to-r from-red-500 to-red-600 h-full w-full transition-all"></div>
+            <div
+              class="bg-gradient-to-r from-red-500 to-red-600 h-full w-full transition-all"
+            ></div>
           </div>
           <p class="text-white text-xl font-bold mt-2">Ogre Minion</p>
           <p class="text-red-400 font-semibold">HP: 100/100</p>
@@ -63,8 +83,11 @@ onMounted(() => {
     <div class="relative z-10 flex justify-center py-8">
       <!-- Player Card Slots -->
       <div class="flex gap-4">
-        <div v-for="(card, index) in playerField" :key="`player-slot-${index}`"
-          class="w-24 h-32 border-2 border-dashed border-blue-400/50 rounded-lg bg-blue-900/20 flex items-center justify-center relative overflow-hidden">
+        <div
+          v-for="(card, index) in playerField"
+          :key="`player-slot-${index}`"
+          class="w-24 h-32 border-2 border-dashed border-blue-400/50 rounded-lg bg-blue-900/20 flex items-center justify-center relative overflow-hidden"
+        >
           <div v-if="card" class="w-[264px] h-[352px] scale-[0.34] origin-center">
             <CatCardItem :card="card" />
           </div>
@@ -77,9 +100,14 @@ onMounted(() => {
       <!-- Player's Hand -->
       <div class="flex justify-center gap-1 px-4 mb-4">
         <TransitionGroup name="hand-card">
-          <div v-for="(card, index) in playerHand" v-show="showHand" :key="card.id"
+          <div
+            v-for="(card, index) in playerHand"
+            v-show="showHand"
+            :key="card.id"
             class="hover:-translate-y-8 transition-transform duration-300 cursor-pointer w-[211px] scale-[0.8]"
-            :style="{ transitionDelay: `${index * 100}ms` }" @click="playCard(card)">
+            :style="{ transitionDelay: `${index * 100}ms` }"
+            @click="playCard(card)"
+          >
             <CatCardItem :card="card" />
           </div>
         </TransitionGroup>
@@ -87,20 +115,39 @@ onMounted(() => {
 
       <!-- Deck in Bottom Right -->
       <div class="absolute bottom-4 right-8">
-        <img :src="deckImage" alt="Deck"
-          class="w-32 h-44 object-contain drop-shadow-xl cursor-pointer hover:scale-105 transition-transform" />
+        <img
+          :src="deckImage"
+          alt="Deck"
+          class="w-32 h-44 object-contain drop-shadow-xl cursor-pointer hover:scale-105 transition-transform"
+        />
         <div
-          class="absolute -top-2 -right-2 bg-purple-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold border-2 border-white">
+          class="absolute -top-2 -right-2 bg-purple-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold border-2 border-white"
+        >
           0
         </div>
       </div>
+
+      <!-- Collection Button in Bottom Left -->
+      <div class="absolute bottom-4 left-8">
+        <button
+          @click="openCollection"
+          class="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-bold px-6 py-3 rounded-full shadow-lg transform transition-all hover:scale-105 active:scale-95 flex items-center gap-2"
+        >
+          📚 My Collection
+          <span class="bg-white/20 rounded-full px-2 py-1 text-sm">{{
+            gameStore.userCollection.length
+          }}</span>
+        </button>
+      </div>
     </div>
+
+    <!-- Collection Modal -->
+    <CollectionModal v-if="showCollection" @close="closeCollection" />
   </div>
 </template>
 
 <style scoped>
 @keyframes float {
-
   0%,
   100% {
     transform: translateY(0);

--- a/src/components/modals/CollectionModal.vue
+++ b/src/components/modals/CollectionModal.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useGameStore } from '@/stores/gameStore'
+import type { Rarity } from '@/types/game'
+import CatCardItem from '@/components/game/CatCardItem.vue'
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const gameStore = useGameStore()
+
+const rarityOrder: Rarity[] = ['legendary', 'epic', 'rare', 'uncommon', 'common']
+const rarityColors = {
+  legendary: 'text-yellow-400',
+  epic: 'text-purple-400',
+  rare: 'text-blue-400',
+  uncommon: 'text-green-400',
+  common: 'text-gray-400',
+}
+
+// Organize cards by rarity for better display
+const cardsByRarity = computed(() => {
+  const grouped = rarityOrder.reduce(
+    (acc, rarity) => {
+      acc[rarity] = gameStore.getCardsByRarity(rarity)
+      return acc
+    },
+    {} as Record<Rarity, typeof gameStore.userCollection>,
+  )
+
+  return grouped
+})
+
+const totalCards = computed(() => gameStore.userCollection.length)
+
+const handleClose = () => {
+  emit('close')
+}
+
+const resetProgress = () => {
+  if (confirm('Are you sure you want to reset all progress? This cannot be undone.')) {
+    gameStore.resetProgress()
+    emit('close')
+  }
+}
+</script>
+
+<template>
+  <div
+    class="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+    @click.self="handleClose"
+  >
+    <div
+      class="bg-gradient-to-br from-purple-100 to-pink-100 rounded-2xl shadow-2xl max-w-6xl w-full max-h-[90vh] p-6 overflow-y-auto"
+    >
+      <!-- Header -->
+      <div class="flex justify-between items-center mb-6">
+        <div>
+          <h2 class="text-4xl font-bold text-purple-900 mb-2">My Collection</h2>
+          <p class="text-purple-700">
+            {{ totalCards }} cards collected | {{ gameStore.totalPacksOpened }} packs opened
+          </p>
+        </div>
+
+        <div class="flex gap-2">
+          <button
+            @click="resetProgress"
+            class="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg font-semibold transition-colors text-sm"
+          >
+            Reset Progress
+          </button>
+          <button
+            @click="handleClose"
+            class="bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-lg font-semibold transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <!-- Collection Display -->
+      <div v-if="totalCards === 0" class="text-center py-12">
+        <div class="text-6xl mb-4">😿</div>
+        <h3 class="text-2xl font-bold text-gray-600 mb-2">No cards yet!</h3>
+        <p class="text-gray-500">Open some card packs to start your collection.</p>
+      </div>
+
+      <div v-else class="space-y-8">
+        <!-- Cards grouped by rarity -->
+        <div v-for="rarity in rarityOrder" :key="rarity" v-show="cardsByRarity[rarity].length > 0">
+          <h3
+            :class="[
+              'text-2xl font-bold mb-4 capitalize flex items-center gap-2',
+              rarityColors[rarity],
+            ]"
+          >
+            {{ rarity }}
+            <span class="text-lg text-gray-600">({{ cardsByRarity[rarity].length }})</span>
+          </h3>
+
+          <div
+            class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4"
+          >
+            <div
+              v-for="card in cardsByRarity[rarity]"
+              :key="`${card.id}-${card.name}`"
+              class="w-full max-w-[240px] mx-auto"
+            >
+              <CatCardItem :card="card" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Stats Summary -->
+      <div v-if="totalCards > 0" class="mt-8 bg-white/50 rounded-lg p-4">
+        <h4 class="text-lg font-bold text-purple-900 mb-3">Collection Stats</h4>
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-4 text-center">
+          <div
+            v-for="rarity in rarityOrder"
+            :key="`stat-${rarity}`"
+            :class="['p-2 rounded-lg bg-white/50', rarityColors[rarity]]"
+          >
+            <div class="text-2xl font-bold">{{ cardsByRarity[rarity].length }}</div>
+            <div class="text-sm capitalize">{{ rarity }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Custom scrollbar for the modal */
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(147, 51, 234, 0.5);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(147, 51, 234, 0.7);
+}
+</style>

--- a/src/composables/cards.ts
+++ b/src/composables/cards.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { drawRarity, drawStats } from '@/game/stats'
 import type { CatCard, TheCatApiImage } from '@/types/game'
 import { isFirstPackClaimed, claimFirstPack } from '@/utils/firstPack'
+import { useGameStore } from '@/stores/gameStore'
 import wizardPackImage from '@/assets/images/packs/wizard_pack.png'
 import warriorPackImage from '@/assets/images/packs/warrior_pack.png'
 import ninjaPackImage from '@/assets/images/packs/ninja_pack.png'
@@ -134,6 +135,8 @@ const generateCatName = (): string => {
 }
 
 export function useCards() {
+  const gameStore = useGameStore()
+
   const fetchCatImages = async (): Promise<void> => {
     if (isFetching || hasFetched) {
       return
@@ -168,6 +171,9 @@ export function useCards() {
 
       cards.value = generate(amount)
       hasFetched = true
+
+      // Save the selected pack ID to the store
+      gameStore.setSelectedPackId(selectedPackId.value)
 
       setTimeout(() => {
         visible.value = true
@@ -238,6 +244,9 @@ export function useCards() {
     if (firstPack) {
       claimFirstPack()
     }
+
+    // Add the generated cards to the user's collection
+    gameStore.addCardsToCollection(result)
 
     return result
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,9 @@ import router from './router'
 import '../src/assets/main.css'
 
 const app = createApp(App)
+const pinia = createPinia()
 
-app.use(createPinia())
+app.use(pinia)
 app.use(router)
 
 app.mount('#app')

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,0 +1,116 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import type { CatCard } from '@/types/game'
+import type { GameProgress } from '@/types/storage'
+import { GameStorage, updateGameProgress } from '@/utils/storage'
+import { defaultGameProgress } from '@/types/storage'
+
+export const useGameStore = defineStore('game', () => {
+  // Load initial state from localStorage
+  const initialState = GameStorage.loadState()
+
+  // Reactive state
+  const progress = ref<GameProgress>({ ...initialState.gameProgress })
+
+  // Computed getters
+  const hasSeenInstructions = computed(() => progress.value.hasSeenInstructions)
+  const hasCompletedTutorial = computed(() => progress.value.hasCompletedTutorial)
+  const currentScreen = computed(() => progress.value.currentScreen)
+  const hasOpenedFirstPack = computed(() => progress.value.hasOpenedFirstPack)
+  const selectedPackId = computed(() => progress.value.selectedPackId)
+  const userCollection = computed(() => progress.value.userCollection)
+  const totalPacksOpened = computed(() => progress.value.totalPacksOpened)
+  const lastPlayedAt = computed(() => progress.value.lastPlayedAt)
+
+  // Actions that also persist to localStorage
+  function setHasSeenInstructions(seen: boolean) {
+    progress.value.hasSeenInstructions = seen
+    updateGameProgress({ hasSeenInstructions: seen })
+  }
+
+  function setHasCompletedTutorial(completed: boolean) {
+    progress.value.hasCompletedTutorial = completed
+    updateGameProgress({ hasCompletedTutorial: completed })
+  }
+
+  function setCurrentScreen(screen: GameProgress['currentScreen']) {
+    progress.value.currentScreen = screen
+    updateGameProgress({ currentScreen: screen })
+  }
+
+  function setHasOpenedFirstPack(opened: boolean) {
+    progress.value.hasOpenedFirstPack = opened
+    updateGameProgress({ hasOpenedFirstPack: opened })
+  }
+
+  function setSelectedPackId(packId: number | null) {
+    progress.value.selectedPackId = packId
+    updateGameProgress({ selectedPackId: packId })
+  }
+
+  function addCardsToCollection(cards: CatCard[]) {
+    // Add new cards to collection (avoiding duplicates by id)
+    const existingIds = new Set(progress.value.userCollection.map((card) => card.id))
+    const newCards = cards.filter((card) => !existingIds.has(card.id))
+
+    progress.value.userCollection = [...progress.value.userCollection, ...newCards]
+    progress.value.totalPacksOpened += 1
+
+    updateGameProgress({
+      userCollection: progress.value.userCollection,
+      totalPacksOpened: progress.value.totalPacksOpened,
+    })
+  }
+
+  function clearCollection() {
+    progress.value.userCollection = []
+    updateGameProgress({ userCollection: [] })
+  }
+
+  function resetProgress() {
+    progress.value = { ...defaultGameProgress }
+    GameStorage.clearState()
+  }
+
+  // Load fresh state from localStorage (useful for debugging or manual refresh)
+  function refreshFromStorage() {
+    const freshState = GameStorage.loadState()
+    progress.value = { ...freshState.gameProgress }
+  }
+
+  // Helper to check if user has cards in collection
+  const hasAnyCards = computed(() => progress.value.userCollection.length > 0)
+
+  // Helper to get cards by rarity
+  function getCardsByRarity(rarity: CatCard['rarity']) {
+    return progress.value.userCollection.filter((card) => card.rarity === rarity)
+  }
+
+  return {
+    // State
+    progress: computed(() => progress.value),
+
+    // Getters
+    hasSeenInstructions,
+    hasCompletedTutorial,
+    currentScreen,
+    hasOpenedFirstPack,
+    selectedPackId,
+    userCollection,
+    totalPacksOpened,
+    lastPlayedAt,
+    hasAnyCards,
+
+    // Actions
+    setHasSeenInstructions,
+    setHasCompletedTutorial,
+    setCurrentScreen,
+    setHasOpenedFirstPack,
+    setSelectedPackId,
+    addCardsToCollection,
+    clearCollection,
+    resetProgress,
+    refreshFromStorage,
+    getCardsByRarity,
+  }
+})

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,0 +1,39 @@
+import type { CatCard } from './game'
+
+export interface GameProgress {
+  // UI state tracking
+  hasSeenInstructions: boolean
+  hasCompletedTutorial: boolean
+  currentScreen: 'instructions' | 'pack-selection' | 'tutorial' | 'battle'
+
+  // Pack and cards data
+  hasOpenedFirstPack: boolean
+  selectedPackId: number | null
+  userCollection: CatCard[]
+
+  // Additional game flags for future features
+  totalPacksOpened: number
+  lastPlayedAt: string // ISO timestamp
+}
+
+export interface StorageState {
+  gameProgress: GameProgress
+  version: string // For future migration handling
+}
+
+// Default game state
+export const defaultGameProgress: GameProgress = {
+  hasSeenInstructions: false,
+  hasCompletedTutorial: false,
+  currentScreen: 'instructions',
+  hasOpenedFirstPack: false,
+  selectedPackId: null,
+  userCollection: [],
+  totalPacksOpened: 0,
+  lastPlayedAt: new Date().toISOString(),
+}
+
+export const defaultStorageState: StorageState = {
+  gameProgress: defaultGameProgress,
+  version: '1.0.0',
+}

--- a/src/utils/firstPack.ts
+++ b/src/utils/firstPack.ts
@@ -1,11 +1,11 @@
-// We purposely do NOT store this in localStorage
-// so every time you refresh, it resets — and you again get a Legendary
-let firstPackClaimed = false
+import { useGameStore } from '@/stores/gameStore'
 
 export function isFirstPackClaimed(): boolean {
-  return firstPackClaimed
+  const gameStore = useGameStore()
+  return gameStore.hasOpenedFirstPack
 }
 
 export function claimFirstPack(): void {
-  firstPackClaimed = true
+  const gameStore = useGameStore()
+  gameStore.setHasOpenedFirstPack(true)
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,153 @@
+import type { StorageState, GameProgress } from '@/types/storage'
+import { defaultStorageState, defaultGameProgress } from '@/types/storage'
+
+const STORAGE_KEY = 'cat-card-battle-state'
+
+/**
+ * Safe localStorage abstraction with TypeScript support
+ * Handles errors gracefully and provides type safety
+ */
+export class GameStorage {
+  /**
+   * Save game state to localStorage
+   * @param state - The complete game state to save
+   * @returns boolean indicating success
+   */
+  static saveState(state: StorageState): boolean {
+    try {
+      const serializedState = JSON.stringify(state)
+      localStorage.setItem(STORAGE_KEY, serializedState)
+      return true
+    } catch (error) {
+      console.warn('❌ Failed to save game state to localStorage:', error)
+      return false
+    }
+  }
+
+  /**
+   * Load game state from localStorage
+   * @returns The loaded state or default state if load fails
+   */
+  static loadState(): StorageState {
+    try {
+      const serializedState = localStorage.getItem(STORAGE_KEY)
+
+      if (!serializedState) {
+        return defaultStorageState
+      }
+
+      const parsedState = JSON.parse(serializedState) as StorageState
+
+      // Validate the structure and migrate if needed
+      const validatedState = this.validateAndMigrateState(parsedState)
+      return validatedState
+    } catch (error) {
+      console.warn('❌ Failed to load game state from localStorage:', error)
+      return defaultStorageState
+    }
+  }
+
+  /**
+   * Update only the game progress portion of the state
+   * @param progressUpdate - Partial game progress to update
+   * @returns boolean indicating success
+   */
+  static updateGameProgress(progressUpdate: Partial<GameProgress>): boolean {
+    try {
+      const currentState = this.loadState()
+      const updatedState: StorageState = {
+        ...currentState,
+        gameProgress: {
+          ...currentState.gameProgress,
+          ...progressUpdate,
+          lastPlayedAt: new Date().toISOString(),
+        },
+      }
+
+      return this.saveState(updatedState)
+    } catch (error) {
+      console.warn('Failed to update game progress:', error)
+      return false
+    }
+  }
+
+  /**
+   * Clear all saved data
+   * @returns boolean indicating success
+   */
+  static clearState(): boolean {
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+      return true
+    } catch (error) {
+      console.warn('Failed to clear game state:', error)
+      return false
+    }
+  }
+
+  /**
+   * Check if localStorage is available
+   * @returns boolean indicating availability
+   */
+  static isStorageAvailable(): boolean {
+    try {
+      const testKey = '__storage_test__'
+      localStorage.setItem(testKey, 'test')
+      localStorage.removeItem(testKey)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Validate and migrate state structure for backwards compatibility
+   * @param state - The state to validate
+   * @returns Validated and migrated state
+   */
+  private static validateAndMigrateState(state: unknown): StorageState {
+    // If the state doesn't have the expected structure, return default
+    if (!state || typeof state !== 'object') {
+      return defaultStorageState
+    }
+
+    const stateObj = state as Record<string, unknown>
+
+    // Check if we have the basic structure
+    if (!stateObj.gameProgress || typeof stateObj.gameProgress !== 'object') {
+      return defaultStorageState
+    }
+
+    // Ensure all required fields exist with proper defaults
+    const migratedProgress: GameProgress = {
+      ...defaultGameProgress,
+      ...(stateObj.gameProgress as Record<string, unknown>),
+    }
+
+    // Validate userCollection is an array
+    if (!Array.isArray(migratedProgress.userCollection)) {
+      migratedProgress.userCollection = []
+    }
+
+    // Validate enums and primitive types
+    if (
+      !['instructions', 'pack-selection', 'tutorial', 'battle'].includes(
+        migratedProgress.currentScreen,
+      )
+    ) {
+      migratedProgress.currentScreen = 'instructions'
+    }
+
+    return {
+      gameProgress: migratedProgress,
+      version: (stateObj.version as string) || '1.0.0',
+    }
+  }
+}
+
+// Convenience functions for easier usage
+export const saveGameState = GameStorage.saveState
+export const loadGameState = GameStorage.loadState
+export const updateGameProgress = GameStorage.updateGameProgress
+export const clearGameState = GameStorage.clearState
+export const isStorageAvailable = GameStorage.isStorageAvailable

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -16,15 +16,19 @@ const showBattle = computed(() => gameStore.currentScreen === 'battle')
 
 // Debug logging
 onMounted(() => {
-  console.log('🎮 LandingPage mounted, current state:')
-  console.log('- hasSeenInstructions:', gameStore.hasSeenInstructions)
-  console.log('- currentScreen:', gameStore.currentScreen)
-  console.log('- hasAnyCards:', gameStore.hasAnyCards)
-  console.log('- hasCompletedTutorial:', gameStore.hasCompletedTutorial)
+  if (import.meta.env.DEV) {
+    console.log('🎮 LandingPage mounted, current state:')
+    console.log('- hasSeenInstructions:', gameStore.hasSeenInstructions)
+    console.log('- currentScreen:', gameStore.currentScreen)
+    console.log('- hasAnyCards:', gameStore.hasAnyCards)
+    console.log('- hasCompletedTutorial:', gameStore.hasCompletedTutorial)
+  }
 
   // Fix screen logic based on saved state
   if (gameStore.hasCompletedTutorial && gameStore.currentScreen !== 'battle') {
-    console.log('🔧 Fixing screen: tutorial completed, should be on battle')
+    if (import.meta.env.DEV) {
+      console.log('🔧 Fixing screen: tutorial completed, should be on battle')
+    }
     gameStore.setCurrentScreen('battle')
   }
 })

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -1,28 +1,58 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { onMounted, computed } from 'vue'
+import { useGameStore } from '@/stores/gameStore'
 import InstructionsModal from '@/components/modals/InstructionsModal.vue'
 import PackSelection from '@/components/game/PackSelection.vue'
 import TutorialSection from '@/components/game/TutorialSection.vue'
 import BattleScene from '@/components/game/BattleScene.vue'
 
-const showModal = ref(true)
-const showPackSelection = ref(false)
-const showTutorial = ref(false)
-const showBattle = ref(false)
+const gameStore = useGameStore()
+
+// Use computed properties based on the store state
+const showModal = computed(() => gameStore.currentScreen === 'instructions')
+const showPackSelection = computed(() => gameStore.currentScreen === 'pack-selection')
+const showTutorial = computed(() => gameStore.currentScreen === 'tutorial')
+const showBattle = computed(() => gameStore.currentScreen === 'battle')
+
+// Debug logging
+onMounted(() => {
+  console.log('🎮 LandingPage mounted, current state:')
+  console.log('- hasSeenInstructions:', gameStore.hasSeenInstructions)
+  console.log('- currentScreen:', gameStore.currentScreen)
+  console.log('- hasAnyCards:', gameStore.hasAnyCards)
+  console.log('- hasCompletedTutorial:', gameStore.hasCompletedTutorial)
+
+  // Fix screen logic based on saved state
+  if (gameStore.hasCompletedTutorial && gameStore.currentScreen !== 'battle') {
+    console.log('🔧 Fixing screen: tutorial completed, should be on battle')
+    gameStore.setCurrentScreen('battle')
+  }
+})
 
 const closeModal = () => {
-  showModal.value = false
-  showPackSelection.value = true
+  gameStore.setHasSeenInstructions(true)
+  gameStore.setCurrentScreen('pack-selection')
 }
 
 const handleCardsRevealed = () => {
-  showPackSelection.value = false
-  showTutorial.value = true
+  gameStore.setCurrentScreen('tutorial')
 }
 
 const handleTutorialComplete = () => {
-  showTutorial.value = false
-  showBattle.value = true
+  gameStore.setHasCompletedTutorial(true)
+  gameStore.setCurrentScreen('battle')
+}
+
+const testSave = () => {
+  console.log('🧪 Testing manual save...')
+  gameStore.setHasSeenInstructions(true)
+  gameStore.setCurrentScreen('pack-selection')
+}
+
+const checkStorage = () => {
+  const raw = localStorage.getItem('cat-card-battle-state')
+  console.log('🔍 Raw localStorage:', raw)
+  alert('Check console for localStorage data')
 }
 </script>
 
@@ -31,7 +61,9 @@ const handleTutorialComplete = () => {
     <!-- Arena Battle Background -->
     <div class="absolute inset-0 bg-gradient-to-b from-purple-900 via-red-900 to-orange-800">
       <!-- Arena floor effect -->
-      <div class="absolute bottom-0 w-full h-1/3 bg-gradient-to-t from-yellow-900/40 to-transparent"></div>
+      <div
+        class="absolute bottom-0 w-full h-1/3 bg-gradient-to-t from-yellow-900/40 to-transparent"
+      ></div>
 
       <!-- Spotlight effects -->
       <div class="absolute top-0 left-1/4 w-96 h-96 bg-yellow-300/20 rounded-full blur-3xl"></div>
@@ -47,7 +79,6 @@ const handleTutorialComplete = () => {
 
     <!-- Main Content -->
     <div v-if="!showBattle" class="relative z-10 min-h-screen flex items-center justify-center p-4">
-
       <!-- Pack Selection -->
       <PackSelection v-if="showPackSelection" @cards-revealed="handleCardsRevealed" />
 

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -16,19 +16,8 @@ const showBattle = computed(() => gameStore.currentScreen === 'battle')
 
 // Debug logging
 onMounted(() => {
-  if (import.meta.env.DEV) {
-    console.log('🎮 LandingPage mounted, current state:')
-    console.log('- hasSeenInstructions:', gameStore.hasSeenInstructions)
-    console.log('- currentScreen:', gameStore.currentScreen)
-    console.log('- hasAnyCards:', gameStore.hasAnyCards)
-    console.log('- hasCompletedTutorial:', gameStore.hasCompletedTutorial)
-  }
-
   // Fix screen logic based on saved state
   if (gameStore.hasCompletedTutorial && gameStore.currentScreen !== 'battle') {
-    if (import.meta.env.DEV) {
-      console.log('🔧 Fixing screen: tutorial completed, should be on battle')
-    }
     gameStore.setCurrentScreen('battle')
   }
 })
@@ -45,18 +34,6 @@ const handleCardsRevealed = () => {
 const handleTutorialComplete = () => {
   gameStore.setHasCompletedTutorial(true)
   gameStore.setCurrentScreen('battle')
-}
-
-const testSave = () => {
-  console.log('🧪 Testing manual save...')
-  gameStore.setHasSeenInstructions(true)
-  gameStore.setCurrentScreen('pack-selection')
-}
-
-const checkStorage = () => {
-  const raw = localStorage.getItem('cat-card-battle-state')
-  console.log('🔍 Raw localStorage:', raw)
-  alert('Check console for localStorage data')
 }
 </script>
 


### PR DESCRIPTION
## Description

<!-- Add a description of the changes. You can paste the issue/feature description  -->
Add functionality to save user progress between sessions.
This should persist the user’s collection, opened packs, and any key gameplay flags (like hasOpenedFirstPack) so that progress isn’t lost when the browser is refreshed or closed.

## Type of Change

<!-- Please check the relevant option(s) -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation
- [ ] 🎨 UI/Style update
- [ ] ♻️ Refactoring

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #19 

## Changes Made

<!-- List the main changes made in this PR -->

- User’s collection and progress persist after page reloads or browser restarts
- Uses a safe abstraction layer for localStorage (saveState / loadState helpers)
- Automatically restores progress on app startup


## Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

### Test Steps

<!-- Provide steps to test the changes -->

1. 


## Checklist

<!-- Check all that apply -->

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Components are properly typed (TypeScript)


